### PR TITLE
Prevent suffocation while riding a pet.

### DIFF
--- a/src/main/java/de/Keyle/MyPet/listeners/PlayerListener.java
+++ b/src/main/java/de/Keyle/MyPet/listeners/PlayerListener.java
@@ -21,6 +21,7 @@
 package de.Keyle.MyPet.listeners;
 
 import de.Keyle.MyPet.MyPetPlugin;
+import de.Keyle.MyPet.entity.types.CraftMyPet;
 import de.Keyle.MyPet.entity.types.InactiveMyPet;
 import de.Keyle.MyPet.entity.types.MyPet;
 import de.Keyle.MyPet.entity.types.MyPet.PetState;
@@ -50,6 +51,7 @@ import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
 import org.bukkit.event.block.Action;
 import org.bukkit.event.entity.EntityDamageByEntityEvent;
+import org.bukkit.event.entity.EntityDamageEvent;
 import org.bukkit.event.entity.PlayerDeathEvent;
 import org.bukkit.event.player.*;
 
@@ -402,6 +404,15 @@ public class PlayerListener implements Listener {
                         }
                     }
                 }, 25L);
+            }
+        }
+    }
+
+    @EventHandler
+    public void onSuffocate(EntityDamageEvent event) {
+        if (event.getCause() == EntityDamageEvent.DamageCause.SUFFOCATION && event.getEntity() instanceof Player) {
+            if (event.getEntity().getVehicle() instanceof CraftMyPet) {
+                event.setCancelled(true);
             }
         }
     }


### PR DESCRIPTION
If a player is riding their pet, and they get too close to a wall, they will begin taking suffocation damage. This seems to at the very least mitigate it.