### PR TITLE
Reversed condition for RemoveAfterRelease.

### DIFF
--- a/modules/Plugin/src/main/java/de/Keyle/MyPet/commands/CommandRelease.java
+++ b/modules/Plugin/src/main/java/de/Keyle/MyPet/commands/CommandRelease.java
@@ -96,7 +96,7 @@ public class CommandRelease implements CommandTabCompleter {
                     }
 
 
-                    if (MyPetApi.getMyPetInfo().getRemoveAfterRelease(myPet.getPetType())) {
+                    if (!MyPetApi.getMyPetInfo().getRemoveAfterRelease(myPet.getPetType())) {
                         LivingEntity normalEntity = (LivingEntity) myPet.getLocation().get().getWorld().spawnEntity(myPet.getLocation().get(), EntityType.valueOf(myPet.getPetType().getBukkitName()));
 
                         Optional<EntityConverterService> converter = MyPetApi.getServiceManager().getService(EntityConverterService.class);


### PR DESCRIPTION
RemoveAfterRelease will be false if the owners want the pet to NOT be removed. Therefore the condition has to be reversed.