### PR TITLE
Make sure Metrics is enabled in bStats config

### DIFF
--- a/modules/Plugin/src/main/java/de/Keyle/MyPet/MyPetPlugin.java
+++ b/modules/Plugin/src/main/java/de/Keyle/MyPet/MyPetPlugin.java
@@ -393,27 +393,29 @@ public class MyPetPlugin extends JavaPlugin implements de.Keyle.MyPet.api.plugin
         // init Metrics
         try {
             Metrics metrics = new Metrics(this);
-            metrics.addCustomChart(new Metrics.SingleLineChart("active_pets", () -> myPetManager.countActiveMyPets()));
-            metrics.addCustomChart(new Metrics.SimplePie("build", MyPetVersion::getBuild));
-            metrics.addCustomChart(new Metrics.SimplePie("update_mode", () -> {
-                String mode = "Disabled";
-                if (Configuration.Update.CHECK) {
-                    mode = "Check";
-                    if (Configuration.Update.DOWNLOAD) {
-                        mode += " & Download";
+            if (metrics.isEnabled()) {
+                metrics.addCustomChart(new Metrics.SingleLineChart("active_pets", () -> myPetManager.countActiveMyPets()));
+                metrics.addCustomChart(new Metrics.SimplePie("build", MyPetVersion::getBuild));
+                metrics.addCustomChart(new Metrics.SimplePie("update_mode", () -> {
+                    String mode = "Disabled";
+                    if (Configuration.Update.CHECK) {
+                        mode = "Check";
+                        if (Configuration.Update.DOWNLOAD) {
+                            mode += " & Download";
+                        }
                     }
+                    return mode;
                 }
-                return mode;
-            }
-            ));
-            metrics.addCustomChart(new Metrics.AdvancedPie("hooks", () -> {
-                Map<String, Integer> activatedHooks = new HashMap<>();
-                for (PluginHook hook : MyPetApi.getPluginHookManager().getHooks()) {
-                    activatedHooks.put(hook.getPluginName(), 1);
+                ));
+                metrics.addCustomChart(new Metrics.AdvancedPie("hooks", () -> {
+                    Map<String, Integer> activatedHooks = new HashMap<>();
+                    for (PluginHook hook : MyPetApi.getPluginHookManager().getHooks()) {
+                        activatedHooks.put(hook.getPluginName(), 1);
+                    }
+                    return activatedHooks;
                 }
-                return activatedHooks;
+                ));
             }
-            ));
         } catch (Throwable e) {
             errorReporter.sendError(e, "Init Metrics failed");
         }


### PR DESCRIPTION
This change is only small and is not required, but if a user has disabled bStats data from being sent in the configuration, do not attempt to send the data to the plugin. This will increase the plugin loading at startup.