### PR TITLE
ReflectionUtil.getClass(): rethrow caught exception

### DIFF
--- a/modules/API/src/main/java/de/Keyle/MyPet/api/util/ReflectionUtil.java
+++ b/modules/API/src/main/java/de/Keyle/MyPet/api/util/ReflectionUtil.java
@@ -33,7 +33,7 @@ public class ReflectionUtil {
         try {
             return Class.forName(name);
         } catch (Throwable ignored) {
-            return Class.class;
+            throw new RuntimeException("failed to load a class", ignored);
         }
     }
 


### PR DESCRIPTION
Current implementation hides all the exceptions of the classes loading process, which makes debugging it difficult.