### PR TITLE
Add some small clearance in the Heal skill check

### DIFF
--- a/modules/Skills/src/main/java/de/Keyle/MyPet/skill/skills/HealImpl.java
+++ b/modules/Skills/src/main/java/de/Keyle/MyPet/skill/skills/HealImpl.java
@@ -73,8 +73,7 @@ public class HealImpl implements Heal {
             myPet.getEntity().ifPresent(entity -> {
                 if (heal.getValue().doubleValue() > 0) {
                     if (timeCounter-- <= 0) {
-
-                        if (myPet.getHealth() < myPet.getMaxHealth()) {
+                        if (myPet.getHealth() < myPet.getMaxHealth() - 0.01f) {
                             if (!particles) {
                                 particles = true;
                                 entity.getHandle().showPotionParticles(Color.LIME);


### PR DESCRIPTION
This avoids an cycle caused by floating point math in certain circumstances where the health is always slightly less that the max which would continuosly print a message on the action bar. There are probably some other comparisons with floating point numbers, but this is a small case I found.