### PR TITLE
Ignore Player Death Event if canceled

### DIFF
--- a/modules/Plugin/src/main/java/de/Keyle/MyPet/listeners/PlayerListener.java
+++ b/modules/Plugin/src/main/java/de/Keyle/MyPet/listeners/PlayerListener.java
@@ -467,7 +467,7 @@ public class PlayerListener implements Listener {
         }
     }
 
-    @EventHandler
+    @EventHandler(ignoreCancelled = true)
     public void on(final PlayerDeathEvent event) {
         if (WorldGroup.getGroupByWorld(event.getEntity().getWorld()).isDisabled()) {
             return;


### PR DESCRIPTION
This event doesn't check if it has been cancelled. there for it's  possible drops all items in a pets inventory, even if the event was cancelled.